### PR TITLE
fix: for windows users

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -77,7 +77,12 @@ yargs(hideBin(process.argv))
       const stats = await fs.promises.stat(input);
 
       if (stats.isDirectory()) {
-        const files = await glob(resolve(input, "**", globPattern));
+        let files = await glob(resolve(input, "**", globPattern), {});
+
+        if (sep === "\\") {
+          files = files.map((path) => path.replaceAll("/", sep));
+        }
+
         const inpath = resolve(input);
         for (const file of files) {
           if (


### PR DESCRIPTION
Hello there! Hopefully you're open to PR with fixes :)

glob outputs filepaths with `/` separators, regardless of platform its run on and [it doesn't look like they're going to change that](https://github.com/isaacs/node-glob#windows). On windows this makes `svelte-strip` output files starting from top of the drive, instead of repository's directory.

Running `svelte-strip strip src/ dist/` and added some console logs to inspect it:

### Before fix:

```
// glob's result:
files: [
  'E:/dev/repo/packages/clientCommons/src/components/CardSuits.svelte',
   ...
]

// in loop, for single file:
        sep:     \
        inpath:  E:\dev\repo\packages\clientCommons\src
        infile:  E:/dev/repo/packages/clientCommons/src/components/CardSuits.svelte
        slice:   /components/CardSuits.svelte
        outfile: E:\components\CardSuits.svelte

// In functions:
makeDirectoryStructure( E:\components\CardSuits.svelte )
strip( E:/dev/repo/packages/clientCommons/src/components/CardSuits.svelte, E:\components\CardSuits.svelte, true )
```

### After fix:

```
// glob's result manipulated:
files: [
  'E:\\dev\\repo\\packages\\clientCommons\\src\\components\\CardSuits.svelte',
...
]

// in loop, for single file:
        sep:     \
        inpath:  E:\dev\repo\packages\clientCommons\src
        infile:  E:\dev\repo\packages\clientCommons\src\components\CardSuits.svelte
        slice:   \components\CardSuits.svelte
        outfile: E:\dev\repo\packages\clientCommons\dist\components\CardSuits.svelte

// In functions:
makeDirectoryStructure( E:\dev\repo\packages\clientCommons\dist\components\CardSuits.svelte )
strip( E:\dev\repo\packages\clientCommons\src\components\CardSuits.svelte, E:\dev\repo\packages\clientCommons\dist\components\CardSuits.svelte, true )
```

I've left out console logs in my [windows-fix branch](https://github.com/Zielak/svelte-strip/tree/windows-fix)